### PR TITLE
Update scoreboard.res

### DIFF
--- a/resource/ui/scoreboard.res
+++ b/resource/ui/scoreboard.res
@@ -14,6 +14,7 @@
 		"enabled"		"1"
 		"tabPosition"		"0"
 		"medal_width"		"20"
+		"medal_column_width" "18"
 		"avatar_width"		"65"
 		"spacer"			"5"
 		"name_width"		"118"


### PR DESCRIPTION
This made me able to see the Casual medals in the scoreboard again. It likely broke due to the UI Scaling update.