### PR TITLE
Minor clean-ups

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Eniere
+Copyright (c) 2014 Eniere
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Eniere's Improved default HUD ver. 3.9.2
+Eniere's Improved Default HUD version 3.9.2
 January 26th, 2022
 
-This is not a custom HUD in its usual meaning, but some fixes for standard Team Fortress 2 UI, adding HP numbers on target IDs, reworked Medic UI, popular custom crosshairs, and more.
+This is not a custom HUD in its usual meaning, but some fixes for the standard Team Fortress 2 UI such as adding HP numbers on target IDs, reworked Medic UI, popular custom crosshairs and more.
 Improved default HUD development is complete. No new features are planned — only support for the upcoming major TF2 updates.
 
-Gallery: https://imgur.com/a/l9qai
+Gallery: https://web.archive.org/web/20230516150753/https://imgur.com/a/l9qai
 
 Recent changes:
 v 3.9.2 (January 26th, 2022)
@@ -16,12 +16,10 @@ v 3.9.2 (January 26th, 2022)
 - minor "under-the-hood" changes.
 
 How-to and changelog:
-http://eniere.github.io
+https://wiki.teamfortress.com/wiki/User:Eniere/Improved_Default_HUD
 
 Discussions:
 http://teamfortress.tv/thread/16751/improved-default-hud
 http://etf2l.org/forum/customise/topic-28385
 
-Please, use Notepad++ (http://notepad-plus-plus.org) to preview or edit files.
-
-Support me: https://huds.tf/site/s-Improved-default-HUD
+Use Notepad++ (http://notepad-plus-plus.org) to preview or edit files.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ http://teamfortress.tv/thread/16751/improved-default-hud
 http://etf2l.org/forum/customise/topic-28385
 
 Use Notepad++ (http://notepad-plus-plus.org) to preview or edit files.
+
+Page on comfig.app: https://comfig.app/huds/page/improved-default-hud/

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
-Eniere's Improved Default HUD version 3.9.2
-January 26th, 2022
+![banner](https://raw.githubusercontent.com/mastercomfig/hud-db/main/hud-resources/improved-default-hud/improved-default-hud-banner.webp)
 
 This is not a custom HUD in its usual meaning, but some fixes for the standard Team Fortress 2 UI such as adding HP numbers on target IDs, reworked Medic UI, popular custom crosshairs and more.
 Improved default HUD development is complete. No new features are planned — only support for the upcoming major TF2 updates.
 
 Gallery: https://web.archive.org/web/20230516150753/https://imgur.com/a/l9qai
 
-Recent changes:
-v 3.9.2 (January 26th, 2022)
+How-to: https://wiki.teamfortress.com/wiki/User:Eniere/Improved_Default_HUD
+
+Discussions:
+- http://teamfortress.tv/thread/16751/improved-default-hud
+- http://etf2l.org/forum/customise/topic-28385
+
+Page on comfig.app: https://comfig.app/huds/page/improved-default-hud/  
+
+### Changelog
+#### Version 3.9.2 (January 26th, 2022)
 - updated to support latest updates;
 - vaccinator icon fix;
 - missed resource/fonts/Surface.otf font file is back;
@@ -15,13 +22,4 @@ v 3.9.2 (January 26th, 2022)
 - removed double crosshair when coaching;
 - minor "under-the-hood" changes.
 
-How-to and changelog:
-https://wiki.teamfortress.com/wiki/User:Eniere/Improved_Default_HUD
-
-Discussions:
-http://teamfortress.tv/thread/16751/improved-default-hud
-http://etf2l.org/forum/customise/topic-28385
-
-Use Notepad++ (http://notepad-plus-plus.org) to preview or edit files.
-
-Page on comfig.app: https://comfig.app/huds/page/improved-default-hud/
+Use [Notepad++](http://notepad-plus-plus.org) to preview and edit files.

--- a/info.vdf
+++ b/info.vdf
@@ -1,14 +1,4 @@
-"idhud-master"
-{
-"ui_version" "3"
-}
-
 "idhud"
 {
-"ui_version" "3"
-}
-
-"hud"
-{
-"ui_version" "3"
+    "ui_version" "3"
 }


### PR DESCRIPTION
- Remove unnecessary extension from LICENSE file and change copyright year to original launch year.
- Move README file to main folder for easier access.
- Made the README more modern and [cooler](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.kym-cdn.com%2Fentries%2Ficons%2Ffacebook%2F000%2F023%2F194%2Fcover1.jpg&f=1&nofb=1&ipt=f9a3516da2b5d5904a15399c5c0acf9e6e954e1310454109712a9940eec0732a).
- `info.vdf` file can have anything as a name; it doesn't need to be the same name as the folder in `tf/custom`. (I've tested with the folder named `idhud-master` and in `info.vdf` there only was `babababoey` with ui_version 3 and it worked.) So only leaving one entry here is sufficient.