### PR TITLE
Custom XHair and hit indicator changes

### DIFF
--- a/scripts/hudanimations_manifest.txt
+++ b/scripts/hudanimations_manifest.txt
@@ -1,20 +1,15 @@
+// Uncomment (remove "//") to enable desired preferences
+// Remember to add "//" if changing from one Uber preference to another; default is small uber value
 hudanimations_manifest
-
 {
-	"file"			"scripts/hudanimations.txt"
-	
-//	Uncomment (remove "//") the line below to enable custom colors:
-	"file"			"advanced/scripts/hudanimations_tf - small uber value.txt"
-	
-//	Uncomment the line below to enable custom colors:	
-//	"file"			"advanced/scripts/hudanimations_tf - large uber value.txt"
-	
-//	Uncomment the line below to enable custom colors:	
-//	"file"			"advanced/scripts/hudanimations_tf - combined uber layout.txt"
+	"file"			"scripts/hudanimations.txt"													// Default game file; don't touch!
 
-//	Uncomment the line below to enable hit indicator:	
-	"file"			"scripts/hudanimations_tf - hit indicator.txt"
-	
-	"file"			"scripts/hudanimations_tf - idhud.txt"
-	"file"			"scripts/hudanimations_tf.txt"
+	"file"			"advanced/scripts/hudanimations_tf - small uber value.txt"					// Small ubercharge value under the crosshair (default IDHUD setting)
+//	"file"			"advanced/scripts/hudanimations_tf - large uber value.txt"					// Large ubercharge value
+//	"file"			"advanced/scripts/hudanimations_tf - combined uber layout.txt"				// Large ubercharge value and small value under crosshair (combined)
+
+//	"file"			"scripts/hudanimations_tf - hit indicator.txt"								// Uncomment to enable hit indicator
+
+	"file"			"scripts/hudanimations_tf - idhud.txt"										// IDHUD file; don't touch!
+	"file"			"scripts/hudanimations_tf.txt"												// Default game file; don't touch!
 }

--- a/scripts/hudanimations_tf - hit indicator.txt
+++ b/scripts/hudanimations_tf - hit indicator.txt
@@ -3,22 +3,22 @@ event DamagedPlayer
 	StopEvent		HitMarker	0.0
 	RunEvent		HitMarker	0.01
 }
-	
+
 event HitMarker
 {
-	
-//	COD-like Hit Indicator. 
-//	To use it, change "visible" to "1" for "CODxhair" (line 348) in the hudcrosshairs.res file:
-	
+
+//	COD-like Hit Indicator.
+//	To use it, change "visible" to "1" for "CODxhair" (line 350) in the "hudcrosshairs.res" file:
+
 	Animate 		CODxhairLeftTop  		FgColor 	"CustomWhite" 				Linear 0.0 0.0001
-	Animate 		CODxhairLeftTop 		FgColor 	"CustomTransparent" 		Linear 0.15 0.1	
+	Animate 		CODxhairLeftTop 		FgColor 	"CustomTransparent" 		Linear 0.15 0.1
 	Animate 		CODxhairLeftBottom 		FgColor 	"CustomWhite" 				Linear 0.0 0.0001
 	Animate 		CODxhairLeftBottom 		FgColor 	"CustomTransparent" 		Linear 0.15 0.1
 	Animate 		CODxhairRightTop 		FgColor 	"CustomWhite" 				Linear 0.0 0.0001
 	Animate 		CODxhairRightTop 		FgColor 	"CustomTransparent" 		Linear 0.15 0.1
 	Animate 		CODxhairRightBottom 	FgColor 	"CustomWhite" 				Linear 0.0 0.0001
 	Animate 		CODxhairRightBottom 	FgColor 	"CustomTransparent" 		Linear 0.15 0.1
-	
+
 //	You can also use any custom crosshair as hit indicator as well:
 //-----------------------------------------------------------------------------------------------------
 //				| 	Custom crosshair name	|		|	1st line: crosshair color	|
@@ -26,8 +26,8 @@ event HitMarker
 //				| 	hudcrosshairs.res		|		|	2nd line: default 			|
 //				|							|		|	crosshair color				|
 //-----------------------------------------------------------------------------------------------------
-	
+
 	Animate 		Dot 					FgColor 	"CustomRed" 				Linear 0.0 0.0001
 	Animate 		Dot 					FgColor 	"CustomWhite" 				Linear 0.15 0.1
-	
+
 }

--- a/scripts/hudcrosshairs.res
+++ b/scripts/hudcrosshairs.res
@@ -1,7 +1,5 @@
-//	Install HUD fonts (idhud-master\resource\fonts\) before editing!
-
-#base "../basefiles/hudlayout.res"
-#base "../scripts/hudcrosshairs.res"
+// If there are any problems, try installing HUD fonts (idhud/resource/fonts/) into your system
+// To enable a crosshair, change the respective crosshair's "visible" value from "0" to "1"
 
 "Resource/HudLayout.res"
 {
@@ -208,7 +206,7 @@
 		"textAlignment"		"center"
 		"fgcolor"			"CustomWhite"
 	}
-	
+
 	RoundBracketsCross		//1.13
 	{
 		"controlName"		"CExLabel"
@@ -225,7 +223,7 @@
 		"textAlignment"		"center"
 		"fgcolor"			"CustomWhite"
 	}
-	
+
 	RoundBracketsDot		//1.14
 	{
 		"controlName"		"CExLabel"
@@ -242,7 +240,7 @@
 		"textAlignment"		"center"
 		"fgcolor"			"CustomWhite"
 	}
-	
+
 	RoundBrackets			//1.15
 	{
 		"controlName"		"CExLabel"
@@ -368,7 +366,7 @@
 			"zpos"				"1"
 			"font"				"CODHitmarker"
 			"labelText"			"\"
-			"textAlignment"		"center" 
+			"textAlignment"		"center"
 		}
 		"CODxhairLeftBottom"
 		{
@@ -385,7 +383,7 @@
 			"zpos"				"1"
 			"font"				"CODHitmarker"
 			"labelText"			"/"
-			"textAlignment"		"center" 
+			"textAlignment"		"center"
 		}
 		"CODxhairRightTop"
 		{
@@ -402,7 +400,7 @@
 			"zpos"				"1"
 			"font"				"CODHitmarker"
 			"labelText"			"/"
-			"textAlignment"		"center" 
+			"textAlignment"		"center"
 		}
 		"CODxhairRightBottom"
 		{
@@ -419,7 +417,7 @@
 			"zpos"				"1"
 			"font"				"CODHitmarker"
 			"labelText"			"\"
-			"textAlignment"		"center" 
+			"textAlignment"		"center"
 		}
 	}
 

--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -1,7 +1,8 @@
-//	Crosshairs section moved to separate file (idhud-master\scripts\hudcrosshairs.res)
+// Crosshairs section moved to separate file (idhud/scripts/hudcrosshairs.res)
+// Uncomment (remove "//") from the second #base line of this file to allow the HUD to load custom crosshairs
 
 #base "../basefiles/hudlayout.res"
-#base "../scripts/hudcrosshairs.res"
+//#base "../scripts/hudcrosshairs.res"
 
 "Resource/HudLayout.res"
 {
@@ -14,12 +15,12 @@
 		"wide"					"f0"
 		"tall"					"480"
 	}
-	
+
 	HudDeathNotice
 	{
 		"MaxDeathNotices" 		"6"
 	}
-	
+
 	HudCloseCaption
 	{
 		"xpos"					"c-250"
@@ -33,7 +34,7 @@
 		"ItemFadeOutTime"		"0.3"
 		"topoffset"				"0"
 	}
-	
+
 	HudTournament
 	{
 		"fieldName"				"HudTournament"
@@ -46,7 +47,7 @@
 		"wide"					"250"
 		"tall"					"80"
 	}
-	
+
 	HudTournamentSetup
 	{
 		"fieldName"				"HudTournamentSetup"
@@ -58,7 +59,7 @@
 		"wide"					"180"
 		"tall"					"65"
 	}
-	
+
 	"CTFStreakNotice"
 	{
 		"fieldName"				"CTFStreakNotice"
@@ -71,7 +72,7 @@
 		"bgcolor_override"		"0 0 0 0"
 		"PaintBackgroundType"	"0"
 	}
-	
+
 	DisguiseStatus
 	{
 		"fieldName" 			"DisguiseStatus"


### PR DESCRIPTION
This pull request disables the hit indicator and custom crosshairs files from loading by default.

Also some adjustments to `scripts/hudanimations_manifest.txt` for easier customization and better readability.

Also adjusts the `#base` files in `hudlayout.res` and `hudcrosshairs.res`. As I understand it, `scripts/hudlayout.res` first loads `basefiles/hudlayout.res` (default game file), then loads `scripts/hudcrosshair.res` (if enabled) and then applies IDHUD's changes to `scripts/hudlayout.res`, so it shouldn't be needed to repeat the `#base` lines in `hudcrosshairs.res` too.

-------

Reason for not loading custom xhairs by default is to improve loading times since they're not visible by default, but the file with the xhairs is still loaded by default.

For the hit indicator, I feel the average player won't want this behavior enabled by default, but I could be wrong, so feel free to disagree with me!

Thanks!